### PR TITLE
Update usage.md for using version 3.* of rn-perms only

### DIFF
--- a/website/docs/usage.md
+++ b/website/docs/usage.md
@@ -29,13 +29,13 @@ PitchDetector.removeListener()
 To use microphone we need give permission to our app, for that we use a [react-native-permissions](https://github.com/zoontek/react-native-permissions) library.
 
 ```shell
- yarn add react-native-permissions
+ yarn add react-native-permissions@3
 ```
 
 Or using npm:
 
 ```shell
-npm install react-native-permissions
+npm install react-native-permissions@3
 ```
 
 After that, on `package.json` file add de following lines:


### PR DESCRIPTION
Version 4.* causes this error:

```
 LOG  AUDIO PERMISSION: _NativePermissionsModule.default.checkPermission is not a function (it is undefined)
 LOG  AUDIO PERMISSION: _NativePermissionsModule.default.checkPermission is not a function (it is undefined)
 LOG  AUDIO PERMISSION: _NativePermissionsModule.default.checkPermission is not a function (it is undefined)
 WARN  [Error: The package 'react-native-pitch-detector' need audio record permission. Make sure: 

- You have added '<uses-permission android:name="android.permission.RECORD_AUDIO" />' on AndroidManifest.xml and request permission before start record.
]
```